### PR TITLE
Upgrade virtualenv

### DIFF
--- a/roles/common/tasks/main.yaml
+++ b/roles/common/tasks/main.yaml
@@ -35,5 +35,12 @@
   sudo: yes
 
 - name: Install tox
-  pip: name=tox
+  pip: name=tox state=latest
   sudo: yes
+
+# virtualenv bundles its own copy of pip and setuptools which are then used by
+# tox. Older versions wont work with some OpenStack requirements such as pbr.
+# If there is somehow a version of virtualenv installed already, the install of
+# tox above wont install the latest, so we ensure that here.
+- name: Update virtualenv
+  command: sudo pip install -IU virtualenv

--- a/roles/validations/meta/main.yaml
+++ b/roles/validations/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - { role: common }

--- a/roles/validations/tasks/main.yaml
+++ b/roles/validations/tasks/main.yaml
@@ -5,11 +5,6 @@
   become: yes
   become_user: stack
 
-- name: Update pip
-  pip: name=pip state=latest virtualenv=/home/stack/clapper/ansible-tests/.venv
-  become: yes
-  become_user: stack
-
 - name: Install requirements
   pip: requirements=/home/stack/clapper/ansible-tests/requirements.txt virtualenv=/home/stack/clapper/ansible-tests/.venv
   become: yes


### PR DESCRIPTION
This is the correct solution to the old-pip problem that was
partially solved in 273a305857306ede63cfd50b125a305a6c0cd219.
Upgrading virtualenv means that all the virtualenvs (and tox
virtualenvs) will be using a modern pip and setuptools.
